### PR TITLE
Prepare compatibility with 4.3 / repository management

### DIFF
--- a/app/views/projects/settings/_repository_checkout.html.erb
+++ b/app/views/projects/settings/_repository_checkout.html.erb
@@ -1,16 +1,17 @@
+<% unless repository.nil? %>
 <%= render partial: 'shared/checkout_header' %>
 <div class="form--field">
   <%= form.select(:checkout_overwrite, [
     [l(:general_text_Yes), "1"],
     [l(:general_text_No), "0"]
   ],
-  {},
-  :onchange => <<-EOF
+  { selected: repository.checkout_overwrite },
+  onchange: <<-EOF
     Effect.toggle($('checkout_settings'), 'slide', {duration:0.2});
   EOF
   )%>
 </div>
-<div id="checkout_settings" <%= 'style="display:none;"'.html_safe unless form.object.checkout_overwrite? %>>
+<div id="checkout_settings" <%= 'style="display:none;"'.html_safe unless repository.checkout_overwrite? %>>
   <div class="form--section">
     <h3 class="form--section-title"><%=l :label_checkout %></h3>
     <div class="form--field">
@@ -23,8 +24,8 @@
 
     <%= javascript_tag do %>
       var protocolForm = new Subform(
-        '<%= escape_javascript(render(:partial => "projects/settings/repository_checkout_protocol", :locals => {:protocol => OpenProject::Checkout::Protocol.new({:protocol => form.object.type.demodulize, :append_path => form.object.allow_subtree_checkout? ? 1: 0, :repository => form.object})})) %>',
-        <%= form.object.checkout_protocols.length %>,
+        '<%= escape_javascript(render(:partial => "projects/settings/repository_checkout_protocol", :locals => {:protocol => OpenProject::Checkout::Protocol.new({:protocol => repository.type.demodulize, :append_path => repository.allow_subtree_checkout? ? 1: 0, :repository => repository})})) %>',
+        <%= repository.checkout_protocols.length %>,
         'checkout_protocol_table'
       );
     <% end %>
@@ -45,7 +46,7 @@
         <th class="protocol_delete"       ></th>
       </tr></thead>
       <tbody id="checkout_protocol_table">
-        <% form.object.checkout_protocols.each_with_index do |protocol, index| %>
+        <% repository.checkout_protocols.each_with_index do |protocol, index| %>
           <%= render :partial => 'projects/settings/repository_checkout_protocol', :locals => {:protocol => protocol, :index => index, :classes => cycle('odd', 'even')} %>
         <% end %>
       </tbody>
@@ -53,3 +54,4 @@
     <div style="text-align: right"><%= link_to_function l(:button_add_protocol), "protocolForm.add()", {:class => "icon icon-add"} %></div>
   </div>
 </div>
+<% end %>

--- a/app/views/settings/_checkout.html.erb
+++ b/app/views/settings/_checkout.html.erb
@@ -1,20 +1,5 @@
 <%= render partial: 'shared/checkout_header' %>
 <%= styled_form_tag :action => 'edit', :tab => 'checkout' do %>
-  <%= javascript_tag do %>
-  var protocolForms = $H();
-  document.observe("dom:loaded", function() {
-    $('tab-content-checkout').select('fieldset.collapsed').each(function(e){
-      e.down('div').hide();
-    });
-    <%
-      OpenProject::Checkout::CheckoutHelper.supported_scm.select{|scm| Setting.enabled_scm.include?(scm)}.each do |scm|
-        next if Setting.send("checkout_overwrite_description_#{scm}?")
-    -%>
-    $('settings_checkout_description_<%= scm %>').up('div').up('div').hide();
-    <%- end %>
-  });
-  <% end %>
-
   <div class="form--section settings">
     <div class="form--field">
       <%= setting_select :checkout_display_checkout_info, [
@@ -31,11 +16,13 @@
 
     <div id="protocol_table">
       <% OpenProject::Checkout::CheckoutHelper.supported_scm.select{|scm| Setting.enabled_scm.include?(scm)}.each do |scm| -%>
-      <fieldset class="header_collapsible collapsible collapsed">
-        <legend title="<%= Repository.const_get(scm).scm_name %>" onclick="toggleFieldset(this);">
-          <a href="javascript:"><%= Repository.const_get(scm).scm_name %></a>
+      <% collapsed = Setting.send("checkout_overwrite_description_#{scm}?") != true %>
+      <fieldset id="checkout_protocol_<%= scm %>"
+                class="form--fieldset -collapsible <%= collapsed ? 'collapsed' : '' %>">
+        <legend class="form--fieldset-legend" title="<%= scm %>" onclick="toggleFieldset(this);">
+          <a href="javascript:"><%= scm %></a>
         </legend>
-        <div><%= render :partial => 'checkout_scm', :locals => {:scm => scm} %></div>
+        <div style=" <%= collapsed ? 'display: none' : '' %>"><%= render :partial => 'checkout_scm', :locals => {:scm => scm} %></div>
       </fieldset>
       <%- end %>
     </div>

--- a/app/views/settings/_checkout_scm.html.erb
+++ b/app/views/settings/_checkout_scm.html.erb
@@ -1,8 +1,7 @@
 <div>
   <div class="form--field">
-    <%= setting_check_box "checkout_overwrite_description_#{scm}", :label => :setting_checkout_overwrite_description, :onclick => <<-EOF
-      Effect.toggle($('settings_checkout_description_#{scm}').up("div").up("div"), 'slide', {duration:0.2});
-    EOF
+    <%= setting_check_box "checkout_overwrite_description_#{scm}",
+                          label: :setting_checkout_overwrite_description
     %>
   </div>
 
@@ -12,7 +11,7 @@
     <%= wikitoolbar_for "settings_checkout_description_#{scm}" %>
   </div>
   <div class="form--field">
-    <%= setting_check_box "checkout_display_command_#{scm}", :label => :field_checkout_display_command %>
+    <%= setting_check_box "checkout_display_command_#{scm}", :label => :checkout_display_command %>
   </div>
 
   <%= javascript_tag do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,8 +13,8 @@ en:
   setting_checkout_command: "Checkout command"
 
   setting_checkout_overwrite_description: "Overwrite default description"
-  field_checkout_overwrite: "Overwrite default settings for checkout protocols"
-  field_checkout_display_command: "Display checkout command"
+  checkout_overwrite: "Overwrite default settings for checkout protocols"
+  checkout_display_command: "Display checkout command"
 
   label_protocol_plural: "Protocols"
   button_add_protocol: "Add Protocol"

--- a/lib/open_project/checkout/checkout_helper.rb
+++ b/lib/open_project/checkout/checkout_helper.rb
@@ -1,7 +1,8 @@
 module OpenProject::Checkout::CheckoutHelper
   class << self
     def supported_scm
-      Object.const_defined?("REDMINE_SUPPORTED_SCM") ? REDMINE_SUPPORTED_SCM : Redmine::Scm::Base.all
+      Object.const_defined?("REDMINE_SUPPORTED_SCM") ? REDMINE_SUPPORTED_SCM :
+                                                       OpenProject::Scm::Manager.vendors
     end
   end
 end

--- a/lib/open_project/checkout/engine.rb
+++ b/lib/open_project/checkout/engine.rb
@@ -58,11 +58,6 @@ Please select the desired protocol below to get the URL.
       app.config.plugins_to_test_paths << self.root
     end
 
-    # add our factories to factory girl's load path
-    initializer "checkout.register_factories", :after => "factory_girl.set_factory_paths" do |app|
-      FactoryGirl.definition_file_paths << File.expand_path(self.root.to_s + '/spec/factories') if defined?(FactoryGirl)
-    end
-
     initializer 'checkout.append_migrations' do |app|
       unless app.root.to_s.match root.to_s
         config.paths["db/migrate"].expanded.each do |expanded_path|

--- a/lib/open_project/checkout/hooks.rb
+++ b/lib/open_project/checkout/hooks.rb
@@ -48,4 +48,10 @@ module OpenProject::Checkout
       context[:controller].send(:render_to_string, {:locals => context}.merge(options))
     end
   end
+
+
+  class RepositorySettingsHook < Redmine::Hook::ViewListener
+    render_on :repository_settings_fields,
+              partial: 'projects/settings/repository_checkout'
+  end
 end

--- a/lib/open_project/checkout/patches/repositories_helper_patch.rb
+++ b/lib/open_project/checkout/patches/repositories_helper_patch.rb
@@ -6,24 +6,16 @@ module OpenProject::Checkout
       base.send(:include, InstanceMethods)
 
       base.class_eval do
-        alias_method_chain :repository_field_tags, :checkout
-        alias_method_chain :scm_select_tag, :javascript
+        alias_method_chain :show_settings_save_button?, :checkout
       end
     end
 
     module InstanceMethods
-      def repository_field_tags_with_checkout(form, repository)
-        tags = repository_field_tags_without_checkout(form, repository) || ""
-        return tags if repository.class.name == "Repository"
-        tags + render(:partial => 'projects/settings/repository_checkout', :locals => {:form => form, :repository => repository, :scm => repository.type.demodulize})
-      end
 
-      def scm_select_tag_with_javascript(*args)
-        content_for :header_tags do
-          javascript_include_tag('checkout/subform.js') +
-          stylesheet_link_tag('checkout/checkout.css')
-        end
-        scm_select_tag_without_javascript(*args)
+      ##
+      # As this plugin adds settings to the repository settings page, always show the save button
+      def show_settings_save_button_with_checkout?(repository)
+        true
       end
     end
   end

--- a/lib/open_project/checkout/patches/repository_patch.rb
+++ b/lib/open_project/checkout/patches/repository_patch.rb
@@ -11,7 +11,12 @@ module OpenProject::Checkout
         unloadable
         serialize :checkout_settings, Hash
         after_initialize :init_checkout_settings
+
+        class << self
+          alias_method_chain :permitted_params, :checkout
+        end
       end
+
     end
 
     module ClassMethods
@@ -23,6 +28,27 @@ module OpenProject::Checkout
       def checkout_default_command
         # default implementation
         ""
+      end
+
+      def permitted_params_with_checkout(params)
+
+        # Allow default params to be returned
+        args = permitted_params_without_checkout(params)
+
+        # Merge them with the standard params
+        # from checkout plugins
+        args = args.merge(params.permit(
+          :checkout_overwrite,
+          :checkout_description,
+          :checkout_display_command,
+        ))
+
+        # Whitelist the hash checkout_protocols, if it exists
+        if params.key? :checkout_protocols
+          args.merge(checkout_protocols: params[:checkout_protocols].permit!)
+        else
+          args
+        end
       end
     end
 

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -11,100 +11,105 @@ describe RepositoriesController, :type => :controller do
 
   render_views
 
-  before(:each) do
-    allow(Setting).to receive(:default_language).and_return('en')
-    allow(Setting).to receive(:autofetch_changesets).and_return(false)
+  with_subversion_repository do |repo_dir|
+    before do
+      allow(Setting).to receive(:default_language).and_return('en')
+      allow(Setting).to receive(:autofetch_changesets).and_return(false)
 
-    @repository = Repository::Subversion.create(:project => project,
-             :url => subversion_repository_url)
-    allow(@controller).to receive(:user_setup)
+      @repository = Repository::Subversion.create(
+               project: project,
+               url: "file://#{repo_dir}",
+               scm_type: 'existing'
+      )
+      allow(@controller).to receive(:user_setup)
 
-    setup_subversion_protocols
+      setup_subversion_protocols
 
-    @project = project
-    @project.enabled_module_names << "repository"
-    @project.repository = @repository
-    @project.save!
+      @project = project
+      @project.enabled_module_names << "repository"
+      @project.repository = @repository
+      @project.save!
 
-    User.current = user
-  end
-
-  after(:each) do
-    User.current = nil
-  end
-
-  def get_repo
-    get :show, :project_id => project.id
-  end
-
-  it 'should render 403 on unauthorized access' do
-    User.current = User.new
-
-    get_repo
-    expect(response.code).to eq('403')
-    expect(response).to render_template('common/error')
-  end
-
-  it "should display the protocol selector" do
-    get_repo
-    expect(response).to be_success
-    expect(response).to render_template('show')
-
-    expect(response.body).to have_selector('#checkout_box') do
-      with_tag('a[id=?][href=?]', 'checkout_protocol_subversion', "file:///#{Rails.root.to_s.gsub(%r{config\/\.\.}, '')}/tmp/test/subversion_repository")
-      with_tag('a[id=?][href=?]', 'checkout_protocol_svn+ssh', 'svn+ssh://repouser@svn.foo.bar/svn/subversion_repository')
+      User.current = user
     end
-  end
 
-  it "should display the description" do
-    get_repo
-    expect(response).to be_success
-    expect(response).to render_template('show')
+    after(:each) do
+      User.current = nil
+    end
 
-    expect(response.body).to have_selector('div.repository-info', /Please select the desired protocol below to get the URL/)
-  end
+    def get_repo
+      get :show, :project_id => project.id
+    end
 
-  describe 'display_checkout_info' do
-    it 'should display nothing when "none" is selected' do
-      allow(Setting).to receive(:checkout_display_checkout_info).and_return('none')
+    it 'should render 403 on unauthorized access' do
+      User.current = User.new
 
+      get_repo
+      expect(response.code).to eq('403')
+      expect(response).to render_template('common/error')
+    end
+
+    it "should display the protocol selector" do
       get_repo
       expect(response).to be_success
       expect(response).to render_template('show')
-      expect(response.body).not_to have_selector('div.repository-info')
 
-      get :entry, :project_id => @project.id, :path => "subversion_test/folder/helloworld.rb"
-      expect(response).to be_success
-      expect(response).to render_template('entry')
-      expect(response.body).not_to have_selector('div.repository-info')
+      expect(response.body).to have_selector('#checkout_box') do
+        with_tag('a[id=?][href=?]', 'checkout_protocol_subversion', "file:///#{Rails.root.to_s.gsub(%r{config\/\.\.}, '')}/tmp/test/subversion_repository")
+        with_tag('a[id=?][href=?]', 'checkout_protocol_svn+ssh', 'svn+ssh://repouser@svn.foo.bar/svn/subversion_repository')
+      end
     end
 
-    it 'should display on directory views only when "browse" is selected' do
-      allow(Setting).to receive(:checkout_display_checkout_info).and_return('browse')
-
+    it "should display the description" do
       get_repo
       expect(response).to be_success
       expect(response).to render_template('show')
+
       expect(response.body).to have_selector('div.repository-info', /Please select the desired protocol below to get the URL/)
-
-      get :entry, :project_id => @project.id, :path => "subversion_test/folder/helloworld.rb"
-      expect(response).to be_success
-      expect(response).to render_template('entry')
-      expect(response.body).not_to have_selector('div.repository-info')
     end
 
-    it 'should display on all pages when "everywhere" is selected' do
-      allow(Setting).to receive(:checkout_display_checkout_info).and_return('everywhere')
+    describe 'display_checkout_info' do
+      it 'should display nothing when "none" is selected' do
+        allow(Setting).to receive(:checkout_display_checkout_info).and_return('none')
 
-      get_repo
-      expect(response).to be_success
-      expect(response).to render_template('show')
-      expect(response.body).to have_selector('div.repository-info', /Please select the desired protocol below to get the URL/)
+        get_repo
+        expect(response).to be_success
+        expect(response).to render_template('show')
+        expect(response.body).not_to have_selector('div.repository-info')
 
-      get :entry, :project_id => @project.id, :path => "subversion_test/folder/helloworld.rb"
-      expect(response).to be_success
-      expect(response).to render_template('entry')
-      expect(response.body).to have_selector('div.repository-info')
+        get :entry, :project_id => @project.id, :path => "subversion_test/folder/helloworld.rb"
+        expect(response).to be_success
+        expect(response).to render_template('entry')
+        expect(response.body).not_to have_selector('div.repository-info')
+      end
+
+      it 'should display on directory views only when "browse" is selected' do
+        allow(Setting).to receive(:checkout_display_checkout_info).and_return('browse')
+
+        get_repo
+        expect(response).to be_success
+        expect(response).to render_template('show')
+        expect(response.body).to have_selector('div.repository-info', /Please select the desired protocol below to get the URL/)
+
+        get :entry, :project_id => @project.id, :path => "subversion_test/folder/helloworld.rb"
+        expect(response).to be_success
+        expect(response).to render_template('entry')
+        expect(response.body).not_to have_selector('div.repository-info')
+      end
+
+      it 'should display on all pages when "everywhere" is selected' do
+        allow(Setting).to receive(:checkout_display_checkout_info).and_return('everywhere')
+
+        get_repo
+        expect(response).to be_success
+        expect(response).to render_template('show')
+        expect(response.body).to have_selector('div.repository-info', /Please select the desired protocol below to get the URL/)
+
+        get :entry, :project_id => @project.id, :path => "subversion_test/folder/helloworld.rb"
+        expect(response).to be_success
+        expect(response).to render_template('entry')
+        expect(response.body).to have_selector('div.repository-info')
+      end
     end
   end
 end

--- a/spec/factories/repository_factory.rb
+++ b/spec/factories/repository_factory.rb
@@ -1,9 +1,0 @@
-FactoryGirl.define do
-  factory :svn_repository, class: Repository::Subversion do
-    project
-    url "file:///" + Rails.root.to_s.gsub(%r{config\/\.\.}, '') + "/tmp/test/subversion_repository"
-    root_url "file:///" + Rails.root.to_s.gsub(%r{config\/\.\.}, '') + "/tmp/test/subversion_repository"
-    password ""
-    login ""
-  end
-end

--- a/spec/macros/macro_spec.rb
+++ b/spec/macros/macro_spec.rb
@@ -8,7 +8,8 @@ describe "Macros" do
   include ActionView::Helpers::UrlHelper
 
   let(:project) { FactoryGirl.create(:project) }
-  let(:svn_repository) { FactoryGirl.create(:svn_repository, project: project) }
+  let(:svn_repository) { FactoryGirl.create(:repository_subversion, project: project,
+                                            url: 'file:///tmp/test/svn_repo') }
 
   before(:each) do
     project.enabled_module_names = project.enabled_module_names << "repository"
@@ -23,14 +24,14 @@ describe "Macros" do
   it "should display default checkout url" do
     text = "{{repository}}"
 
-    url = "file:///#{Rails.root.to_s.gsub(%r{config\/\.\.}, '')}/tmp/test/subversion_repository"
+    url = "file:///tmp/test/svn_repo"
     expect(format_text(text)).to eql "<p><a href=\"#{url}\">#{url}</a></p>"
   end
 
   it "should display forced checkout url" do
     text = "{{repository(svn+ssh)}}"
 
-    url = 'svn+ssh://svn.foo.bar/svn/subversion_repository'
+    url = 'svn+ssh://svn.foo.bar/svn/svn_repo'
     expect(format_text(text)).to eql "<p><a href=\"#{url}\">#{url}</a></p>"
   end
 
@@ -48,7 +49,7 @@ describe "Macros" do
     @project = nil
     text = "{{repository(#{project.name}:svn+ssh)}}"
 
-    url = 'svn+ssh://svn.foo.bar/svn/subversion_repository'
+    url = 'svn+ssh://svn.foo.bar/svn/svn_repo'
     expect(format_text(text)).to eql "<p><a href=\"#{url}\">#{url}</a></p>"
   end
 
@@ -56,7 +57,7 @@ describe "Macros" do
     Setting.checkout_display_command_Subversion = '1'
 
     text = "{{repository(svn+ssh)}}"
-    url = 'svn+ssh://svn.foo.bar/svn/subversion_repository'
+    url = 'svn+ssh://svn.foo.bar/svn/svn_repo'
     expect(format_text(text)).to eql "<p>svn co <a href=\"#{url}\">#{url}</a></p>"
   end
 end

--- a/spec/models/protocol_spec.rb
+++ b/spec/models/protocol_spec.rb
@@ -7,7 +7,8 @@ describe OpenProject::Checkout::Protocol, :type => :model do
   let(:user) { FactoryGirl.create(:user) }
   let!(:member) { FactoryGirl.create(:member, user: user, project: project, roles: [role]) }
   let(:admin) { FactoryGirl.create(:admin) }
-  let!(:repo) { FactoryGirl.create(:svn_repository, project: project, url: 'http://example.com/svn/testrepo') }
+  let!(:repo) { FactoryGirl.create(:repository_subversion, project: project,
+                                   url: 'http://example.com/svn/testrepo') }
 
   before(:each) do
     project.enabled_module_names = project.enabled_module_names << "repository"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,15 +36,3 @@ def setup_subversion_protocols
   ]
   }
 end
-
-# Returns the path to the test +vendor+ repository
-def repository_path(vendor)
-  File.join(Rails.root.to_s.gsub(%r{config\/\.\.}, ''), "/tmp/test/#{vendor.downcase}_repository")
-end
-
-# Returns the url of the subversion test repository
-def subversion_repository_url
-  path = repository_path('subversion')
-  path = '/' + path unless path.starts_with?('/')
-  "file://#{path}"
-end


### PR DESCRIPTION
This commit begins to provide compability of the checkout plugin
with the new functionality of repository management coming to 4.3.


Merge depends on https://github.com/opf/openproject/pull/3196